### PR TITLE
Fix weather request error handling

### DIFF
--- a/weatherbot/bot.py
+++ b/weatherbot/bot.py
@@ -108,7 +108,15 @@ class WeatherBot:
             await update.message.reply_text("Неверный формат даты. Попробуйте ещё раз.")
             return SELECTING_DATE
 
-        forecast = self._get_weather_text(location)
+        try:
+            forecast = self._get_weather_text(location)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("Failed to get weather: %s", exc)
+            await update.message.reply_text(
+                "Не удалось получить прогноз. Попробуйте позже."
+            )
+            return ConversationHandler.END
+
         self.db.add_subscription(update.effective_chat.id, location, date_text, forecast)
         await update.message.reply_text(
             f"Подписка добавлена. Погода в {location} на {date_text}:\n{forecast}"


### PR DESCRIPTION
## Summary
- improve error handling when fetching the forecast

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68482a937c0c83288d545090a7300158